### PR TITLE
configure dependabot to check for updates monthly

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,6 +2,6 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "daily"
+    update_schedule: "monthly"
     default_reviewers:
       - "gavinsharp"


### PR DESCRIPTION
For production systems, I think a monthly dependency update cadence is more reasonable than the template-default daily updates. We don't need to stay on the bleeding edge of package updates. Security-related updates will still come through immediately when applicable.