### PR TITLE
fix: update the `ProperLogger.getlogger` to be a singleton factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ And then start logging things:
 import { ProperLogger } from '@goproperly/js-proper-logger';
 
 // Instances of the logger can be created
-const logger = new ProperLogger('get_offer_details');
+const logger = ProperLogger.getLogger('get_offer_details');
 
 // Those instance have methods that allow you to log at different levels of
 // severity. Depending on what the `logger.logLevel` is set at (controlled by
@@ -57,6 +57,11 @@ The logger instances can also be used to record metrics:
 logger.metric('external_call_count', 3);
 // This will log to `console.log` and can be used by CloudWatch insights.
 ```
+
+Instances of the `ProperLogger` should be created using the
+`ProperLogger.getLogger` method. This method will return the same instance of
+the logger depending on the name provided which allows for reusing the same
+logger at different files without passing logger instances between functions.
 
 This is also a concept of "common tags". These tags are recorded in every log message:
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,8 +17,17 @@ export class ProperLogger {
 
   console: Pick<Console, 'debug' | 'log' | 'warn' | 'error'>;
 
+  static loggerInstances: Record<string, ProperLogger> = {};
+
   static getLogger(name: string): ProperLogger {
-    return new ProperLogger(name);
+    const memoizedInstance = ProperLogger.loggerInstances[name];
+    if (memoizedInstance !== undefined) {
+      return memoizedInstance;
+    }
+    const newInstance = new ProperLogger(name);
+    ProperLogger.loggerInstances[name] = newInstance;
+
+    return newInstance;
   }
 
   constructor(name: string, commonTags?: Tags) {

--- a/test/ProperLogger.test.ts
+++ b/test/ProperLogger.test.ts
@@ -22,6 +22,28 @@ describe('ProperLogger', () => {
     return logger;
   }
 
+  describe('getLogger', () => {
+    test('returns different instances when given different names', () => {
+      const logger1 = ProperLogger.getLogger('outrageous fortune');
+      const logger2 = ProperLogger.getLogger('sea of troubles');
+
+      // Note we're using `toBe` rather than `toEqual` not just for the Hamlet
+      // pun, but also because we want to check that these are not the same
+      // instance, and not just equal to one another.
+      expect(logger1).not.toBe(logger2);
+    });
+
+    test('returns the same instance when given the same name', () => {
+      const logger1 = ProperLogger.getLogger('mortal coil');
+      const logger2 = ProperLogger.getLogger('mortal coil');
+
+      // Note we're using `toBe` rather than `toEqual` not just for the Hamlet
+      // pun, but also because we want to check that these are the same
+      // instance, and not just equal to one another.
+      expect(logger1).toBe(logger2);
+    });
+  });
+
   describe('debug', () => {
     test('only message', () => {
       const logger = setupTestLogger();


### PR DESCRIPTION
When trying to add this to the `properly-air-call-integration` (this
first application we're adding the JS `ProperLogger` to) we found that
we were tempted to pass an instance between layers. This lead me to the
conclusion that we were missing "something" because this isn't something
we need to do with the Python `ProperLogger`. The reason why we don't
need to do this with the Python `ProperLogger` is because the
`getLogger` method there keeps track of instances by name and returns
existing instance rather than creating new instances (see:
https://git.io/JUn6A)

This commit adds a similar memoized instance "thing" to the JS
`ProperLogger` by encouraging the use of the `getlogger` static method
which has been changed to return the same instance with when given the
same logger name.

This is a little different from the caching we use in the Python
`ProperLogger` because those reuse the instance of the `logger` rather
than the `ProperLogger` (the `logger` is the internal mechanism that is
wrapper by the `ProperLogger`). This means that here the "common tags"
will be shared which I feel is a desirable property.