### PR TITLE
update dependabot config to use proper commit messages

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,5 +3,9 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "monthly"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true
     default_reviewers:
       - "gavinsharp"


### PR DESCRIPTION
For some reason, dependabot commits against this repo are not using conventional commit-tagged formatted commit messages. I suspect this will prevent `semantic-release` from creating a new release when production dependency updates are merged in.

The dependabot commits for `js-package` do use them, and I don't see any meaningful difference in configuration (comparing both repos' `.dependabot/config.yml` or `package.json`).

This attempts to work around that issue by explicitly configuring dependabot per https://dependabot.com/docs/config-file/#commit_message. Updates to production dependencies (i.e. that could potentially directly affect consumers) will be tagged as `fix`, whereas updates to development dependencies (that shouldn't affect consumers) are marked as `chore` (which does not generate a release).

(Side note: dev dependency updates can in fact still break consumers, if e.g. a `rollup` update contains a bug that breaks the resulting built module somehow. However I think that scenario is rare enough that it makes sense to avoid releases for dev-only dependency updates.)