### PR TITLE
Improve "logging levels" section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ logger.info('Test logging', { exampleTag: 'additional details' });
 // This will call `console.log` with `{'message': 'Test logging', 'exampleTag': 'additional details'}`
 ```
 
-
 ### How does it work
 
 The `ProperLogger` provides us with 3 things:
@@ -51,6 +50,8 @@ and/or understand what happened when something goes wrong.
 The 4 levels of logging loosely correspond to Python's levels of logging:
 `logger.debug`, `logger.info`, `logger.warning` and `logger.error`.
 
+#### Metrics
+
 The logger instances can also be used to record metrics:
 
 ```javascript
@@ -58,10 +59,14 @@ logger.metric('external_call_count', 3);
 // This will log to `console.log` and can be used by CloudWatch insights.
 ```
 
+#### Creating a logger
+
 Instances of the `ProperLogger` should be created using the
 `ProperLogger.getLogger` method. This method will return the same instance of
 the logger depending on the name provided which allows for reusing the same
 logger at different files without passing logger instances between functions.
+
+#### Common tags
 
 This is also a concept of "common tags". These tags are recorded in every log message:
 
@@ -75,6 +80,8 @@ logger.error('MISSING_VALUE_ERROR', "Expected 'x' to be present on 'Vector'");
 logger.clearCommonTags();
 ```
 
+#### Log levels
+
 If you want to decrease the number of logs that the service is creating (for
 example if the service was deployed and has been well behaved for a little
 while) you can change the `PROPERLY_LOG_LEVEL` environment variable. If the
@@ -83,7 +90,6 @@ the console (e.g. if `logger.debug` is called and the `PROPERLY_LOG_LEVEL` is
 set to `LogLevels.DEBUG`, a message will be written to `console.debug`. If the
 `PROPERLY_LOG_LEVEL` log is `LogLevels.INFO` a message will not be written
 to `console.debug`).
-
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ message in a JSON format to the `Console`. These messages written to the
 console are then collected by `CloudWatch` which we then use to create dashboards
 and/or understand what happened when something goes wrong.
 
-The 4 levels of logging loosely correspond to Python's levels of logging:
-`logger.debug`, `logger.info`, `logger.warning` and `logger.error`.
-
 #### Metrics
 
 The logger instances can also be used to record metrics:
@@ -82,13 +79,22 @@ logger.clearCommonTags();
 
 #### Log levels
 
+There are four supported levels of logging, which correspond to Python's levels
+of logging:
+
+- `logger.debug` (10)
+- `logger.info` (20)
+- `logger.warning` (30)
+- `logger.error` (40).
+
 If you want to decrease the number of logs that the service is creating (for
-example if the service was deployed and has been well behaved for a little
-while) you can change the `PROPERLY_LOG_LEVEL` environment variable. If the
-`loggler.logLevel` is less then the method's level nothing will be written to
-the console (e.g. if `logger.debug` is called and the `PROPERLY_LOG_LEVEL` is
-set to `LogLevels.DEBUG`, a message will be written to `console.debug`. If the
-`PROPERLY_LOG_LEVEL` log is `LogLevels.INFO` a message will not be written
+example if the service was deployed and has been well-behaved for a little
+while) you can increase the value of the `PROPERLY_LOG_LEVEL` environment
+variable. If the `loggler.logLevel` is greater than the called logging
+method's level, nothing will be written to the console (e.g. if
+`logger.debug` is called and the `PROPERLY_LOG_LEVEL` is set to
+`LogLevels.DEBUG` (10), a message will be written to `console.debug`. If the
+`PROPERLY_LOG_LEVEL` log is `LogLevels.INFO` (20) a message will not be written
 to `console.debug`).
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ of logging:
 - `logger.debug` (10)
 - `logger.info` (20)
 - `logger.warning` (30)
-- `logger.error` (40).
+- `logger.error` (40)
 
 If you want to decrease the number of logs that the service is creating (for
 example if the service was deployed and has been well-behaved for a little


### PR DESCRIPTION
I always find myself confused about how the log levels work (specifically: whether a higher `logLevel` value means "more logs" or "fewer logs").

I tried referencing this README to clarify my confusion and found what I think is incorrect information:
> If the `loggler.logLevel` is less then the method's level nothing will be written to the console

I think that should be "greater than". I took a stab at rephrasing to clarify how the log levels work.

I also added some subtitles, and added details about the actual log level values in the doc (rather than just referencing the code, which required me to pull up an additional file when I wanted to quickly answer "which log level do I need").