### PR TITLE
remove Gavin as default reviewer

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,5 +7,3 @@ update_configs:
       prefix: "fix"
       prefix_development: "chore"
       include_scope: true
-    default_reviewers:
-      - "gavinsharp"


### PR DESCRIPTION
I opened my personal inbox this morning to discover a whole bunch of dependabot PR notifications and [review request failures](https://github.com/GoProperly/js-proper-logger/pull/113#issuecomment-788074451) (cannot request review from someone who doesn't have write access) for the public Properly repos that I had configured them on 😄. I should've removed myself from the dependabot configs before leaving!

I no longer have write access so submitting this as a PR that I hope someone else will merge. @hockeybuggy would you mind merging this and making this change to the other repos where it applies as well? 🙏

The public ones I see are:
- https://github.com/GoProperly/eslint-config-properly-base/
- https://github.com/GoProperly/eslint-config-properly-react/
- https://github.com/GoProperly/browserslist-config-properly/
- https://github.com/GoProperly/properly-air-call-integration/ (maybe this repo should be private?)

And I think there are some additional private ones (e.g. `www`) that are likely also failing to add me as a reviewer.